### PR TITLE
allow disk cleaning during deploy

### DIFF
--- a/ironic/conf/deploy.py
+++ b/ironic/conf/deploy.py
@@ -66,6 +66,13 @@ opts = [
                       'ramdisk (defaults to 99 for the '
                       'GenericHardwareManager). If set to 0, will not run '
                       'during cleaning.')),
+    cfg.BoolOpt('erase_devices_metadata_during_deploy',
+               default=False,
+               mutable=True,
+               help=_('Whether to wipe metadata from all disks during '
+                      'the deploy process, prior to writing the image. '
+                      'primarily used to address issues when automatic '
+                      'cleaning is disabled. Defaults to False.')),
     cfg.IntOpt('delete_configuration_priority',
                mutable=True,
                help=_('Priority to run in-band clean step that erases '


### PR DESCRIPTION
By default, ironic selects the smallest disk > flavor disk size to use as the boot disk. If more than one disk is the same, smallest size, ironic will pick at random.

Because we don’t clean data between instances, old boot data can be left on “disk B”, while ironic intends to boot from “disk A”.

This can cause:
- the bios/uefi to boot from the old image, preventing user-log in and showing old data
- the efi or other boot partitions to be written to the wrong disk
- cloud-init to read an out-of-date configdrive from the wrong disk
- and due to combinations of the above, cc-snapshot to create images with incorrect boot information.

While we could enable automatic cleaning, this causes a long delay after node deletion before it's again usable, and as our users want to reuse _specific nodes_, they'll get frustrating "No Hosts Available" errors.


To resolve this, we'd like to run the `erase_devices_metadata` cleaning step during deployment instead. While this can be accomplished via ironic's deploy templates, node traits, and having nova flavors require said trait, that would involve maintaining the new trait on every baremetal node, or nova scheduling would fail.

Instead, this PR allows us to enable this behavior by default for all nodes, reusing the same logic for step priority already  used for automated cleaning via `get_clean_steps`.

