### PR TITLE
hack: revert ipmitool special case for supermicro

### DIFF
--- a/ironic/drivers/modules/ipmitool.py
+++ b/ironic/drivers/modules/ipmitool.py
@@ -199,10 +199,11 @@ def _vendor_aware_boot_device_map(task):
     boot_mode = boot_mode_utils.get_boot_mode(node)
     if vendor:
         vendor = str(vendor).lower()
-        if boot_mode == 'uefi' and vendor == "supermicro":
-            # This difference is only known on UEFI mode for supermicro
-            # hardware.
-            boot_dev_map[boot_devices.DISK] = '0x24'
+        # Disable as broken on supermicro H13
+        # if boot_mode == 'uefi' and vendor == "supermicro":
+        #     # This difference is only known on UEFI mode for supermicro
+        #     # hardware.
+        #     boot_dev_map[boot_devices.DISK] = '0x24'
         # NOTE(TheJulia): Similar differences may exist with Cisco UCS
         # hardware when using IPMI, however at present we don't know
         # what the setting would be.

--- a/ironic/tests/unit/drivers/modules/test_ipmitool.py
+++ b/ironic/tests/unit/drivers/modules/test_ipmitool.py
@@ -2649,7 +2649,7 @@ class IPMIToolDriverTestCase(Base):
         mock_calls = [
             mock.call(self.info, "raw 0x00 0x08 0x03 0x08"),
             mock.call(self.info, "raw 0x00 0x08 0x05 0xe0 "
-                                 "0x24 0x00 0x00 0x00")
+                                 "0x08 0x00 0x00 0x00")
         ]
         mock_exec.assert_has_calls(mock_calls)
 
@@ -2670,7 +2670,7 @@ class IPMIToolDriverTestCase(Base):
         mock_calls = [
             mock.call(self.info, "raw 0x00 0x08 0x03 0x08"),
             mock.call(self.info, "raw 0x00 0x08 0x05 0xa0 "
-                                 "0x24 0x00 0x00 0x00")
+                                 "0x08 0x00 0x00 0x00")
         ]
         mock_exec.assert_has_calls(mock_calls)
 


### PR DESCRIPTION
On supermicro H13SRE-F, firmware version 1.05, setting 0x24 for boot device causes `Boot Flag Invalid` to be set.
see https://bugs.launchpad.net/ironic/+bug/2156955